### PR TITLE
seed to create #osu channel

### DIFF
--- a/database/seeds/00001_create_osu_channel.down.sql
+++ b/database/seeds/00001_create_osu_channel.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM channels WHERE name = '#osu';

--- a/database/seeds/00001_create_osu_channel.up.sql
+++ b/database/seeds/00001_create_osu_channel.up.sql
@@ -1,0 +1,3 @@
+INSERT INTO channels (name, topic, read_privileges, write_privileges,
+                      auto_join, created_at, updated_at)
+VALUES ('#osu', 'General discussion', 0, 0, TRUE, NOW(), NOW());


### PR DESCRIPTION
Only created `#osu` since we haven't figured out privileges yet.

Tested locally:
```sh
(venv) cmyui@cmyui:~/programming/profess/osu-server$ make up-seeds 
docker-compose exec osu-server /scripts/seed-db.sh up
Running seeds (up)
1/u create_osu_channel (16.850591ms)
Ran seeds successfully
(venv) cmyui@cmyui:~/programming/profess/osu-server$ make down-seeds 
docker-compose exec osu-server /scripts/seed-db.sh down
Running seeds (down)
Are you sure you want to apply all down migrations? [y/N]
y
Applying all down migrations
1/d create_osu_channel (104.963281ms)
Ran seeds successfully
```