### PR TITLE
INTRN-218: Rewrite logger; notably handling of uvicorn loggers and exception formatting

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - INTRN-218-fix-json-stacktrace-logging
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - INTRN-218-fix-json-stacktrace-logging
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/app/adapters/osu_api_v2.py
+++ b/app/adapters/osu_api_v2.py
@@ -256,7 +256,7 @@ async def lookup_beatmap(
         logger.warning(
             "Beatmap not found",
             checksum=beatmap_md5,
-            filename=file_name,
+            file_name=file_name,
             beatmap_id=beatmap_id,
         )
         return
@@ -267,7 +267,7 @@ async def lookup_beatmap(
         logger.error(
             "Beatmapset is None",
             checksum=beatmap_md5,
-            filename=file_name,
+            file_name=file_name,
             beatmap_id=beatmap_id,
         )
         return

--- a/app/logger.py
+++ b/app/logger.py
@@ -22,6 +22,9 @@ def get_request_id() -> str | None:
     return _REQUEST_ID_CONTEXT.get(None)
 
 
+raise Exception("testing stacktrace stuff")
+
+
 def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
     return structlog.wrap_logger(_ROOT_LOGGER, logger_name=name or "root")
 

--- a/app/logger.py
+++ b/app/logger.py
@@ -83,7 +83,7 @@ def configure_logging(app_env: str, log_level: str | int) -> None:
 
         # format the exception only when using the json renderer
         # we want to pretty-print the exception when logging as text
-        shared_processors.append(structlog.processors.format_exc_info)
+        shared_processors.append(structlog.processors.dict_tracebacks)
 
     structlog.stdlib.ProcessorFormatter.wrap_for_formatter
     structlog.configure(

--- a/app/logger.py
+++ b/app/logger.py
@@ -28,7 +28,7 @@ def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
 
 
 def log_as_text(app_env: str) -> bool:
-    return False
+    return app_env == "local"
 
 
 def add_process_id(_: WrappedLogger, __: str, event_dict: EventDict) -> EventDict:

--- a/app/logger.py
+++ b/app/logger.py
@@ -133,7 +133,8 @@ def configure_logging(app_env: str, log_level: str | int) -> None:
         stdlib_logging.getLogger(_logger).handlers.clear()
         stdlib_logging.getLogger(_logger).propagate = True
 
-    # effectively disable uvicorn.access; we will recreate this via middleware
+    # effectively disable uvicorn.access
+    # TODO: recreate access logs using middleware
     stdlib_logging.getLogger("uvicorn.access").handlers.clear()
     stdlib_logging.getLogger("uvicorn.access").propagate = False
 

--- a/app/logger.py
+++ b/app/logger.py
@@ -47,7 +47,7 @@ def add_request_id(_: WrappedLogger, __: str, event_dict: EventDict) -> EventDic
 
 
 def configure_logging(app_env: str, log_level: str | int) -> None:
-    if log_as_text(app_env):
+    if False:
         renderer = structlog.dev.ConsoleRenderer(colors=log_with_colors(app_env))
     else:
         renderer = structlog.processors.JSONRenderer()

--- a/app/logger.py
+++ b/app/logger.py
@@ -138,9 +138,6 @@ def configure_logging(app_env: str, log_level: str | int) -> None:
     stdlib_logging.getLogger("uvicorn.access").handlers.clear()
     stdlib_logging.getLogger("uvicorn.access").propagate = False
 
-    uvicorn_access_logger = stdlib_logging.getLogger("uvicorn")
-    uvicorn_access_logger.addHandler(handler)
-
 
 def debug(*args, **kwargs) -> None:
     return get_logger().debug(*args, **kwargs)

--- a/app/logger.py
+++ b/app/logger.py
@@ -27,10 +27,7 @@ def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
 
 
 def log_as_text(app_env: str) -> bool:
-    # TODO: fix error with json logger where it does this with stacktraces
-    # https://app.datadoghq.com/logs?query=status%3Aerror%20service%3Ainterns-backend&cols=host%2Cservice&event=AgAAAYg71Zcly_8c2AAAAAAAAAAYAAAAAEFZZzcxYUdLQUFCcHg4RVNkQmlHaGdBTgAAACQAAAAAMDE4ODNiZDUtYzNjMC00OTY1LWFjNWMtZTBiM2Q5YTE5ZTE4&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1680750604418&to_ts=1680751504418&live=true
-    # return app_env == "local"
-    return True
+    return app_env == "local"
 
 
 def log_with_colors(app_env: str) -> bool:

--- a/app/logger.py
+++ b/app/logger.py
@@ -85,13 +85,13 @@ def configure_logging(app_env: str, log_level: str | int) -> None:
     _ROOT_LOGGER.setLevel(log_level)
 
     # defer logging control of all loggers to our root logger
-    # for name in stdlib_logging.root.manager.loggerDict:
-    #     logger = stdlib_logging.getLogger(name)
+    for name in stdlib_logging.root.manager.loggerDict:
+        logger = stdlib_logging.getLogger(name)
 
-    #     logger.propagate = True
-    #     logger.setLevel(log_level)
-    #     for logger_handler in logger.handlers:
-    #         logger.removeHandler(logger_handler)
+        logger.propagate = True
+        logger.setLevel(log_level)
+        for logger_handler in logger.handlers:
+            logger.removeHandler(logger_handler)
 
 
 def debug(*args, **kwargs) -> None:

--- a/app/logger.py
+++ b/app/logger.py
@@ -22,9 +22,6 @@ def get_request_id() -> str | None:
     return _REQUEST_ID_CONTEXT.get(None)
 
 
-raise Exception("testing stacktrace stuff")
-
-
 def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
     return structlog.wrap_logger(_ROOT_LOGGER, logger_name=name or "root")
 

--- a/app/logger.py
+++ b/app/logger.py
@@ -4,11 +4,16 @@ import sys
 import traceback
 from contextvars import ContextVar
 from types import TracebackType
+from typing import TextIO
 
 import structlog
+from rich.console import Console
+from rich.traceback import Traceback
 from structlog.types import EventDict
+from structlog.types import ExcInfo
 from structlog.types import Processor
 from structlog.types import WrappedLogger
+
 
 _ROOT_LOGGER = stdlib_logging.getLogger()
 
@@ -64,6 +69,19 @@ def drop_color_message_key(_, __, event_dict: EventDict) -> EventDict:
     return event_dict
 
 
+def rich_traceback(sio: TextIO, exc_info: ExcInfo) -> None:
+    """
+    We overwrite the default version of this in structlog to set the `max_frames` to 10.
+
+    Being an ASGI server, there are a lot of frames that are not relevant to us, and
+    we don't want to clutter the logs with them; especially when pretty printing.
+    """
+    sio.write("\n")
+    Console(file=sio, color_system="truecolor").print(
+        Traceback.from_exception(*exc_info, show_locals=True, max_frames=10)
+    )
+
+
 def configure_logging(app_env: str, log_level: str | int) -> None:
     shared_processors: list[Processor] = [
         structlog.stdlib.add_log_level,
@@ -74,7 +92,7 @@ def configure_logging(app_env: str, log_level: str | int) -> None:
     ]
 
     if log_as_text(app_env):
-        log_renderer = structlog.dev.ConsoleRenderer()
+        log_renderer = structlog.dev.ConsoleRenderer(exception_formatter=rich_traceback)
     else:
         log_renderer = structlog.processors.JSONRenderer()
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,8 +16,6 @@ logger.configure_logging(
 logger.overwrite_exception_hook()
 atexit.register(logger.restore_exception_hook)
 
-raise Exception("testing stacktrace stuff")
-
 app = FastAPI()
 
 app.host("osu.cmyui.xyz", osu_web_router)

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import atexit
+
 from app import lifecycle
 from app import logger
 from app import settings
@@ -11,7 +13,8 @@ logger.configure_logging(
     app_env=settings.APP_ENV,
     log_level=settings.APP_LOG_LEVEL,
 )
-
+logger.overwrite_exception_hook()
+atexit.register(logger.restore_exception_hook)
 
 raise Exception("testing stacktrace stuff")
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,9 @@ logger.configure_logging(
     log_level=settings.APP_LOG_LEVEL,
 )
 
+
+raise Exception("testing stacktrace stuff")
+
 app = FastAPI()
 
 app.host("osu.cmyui.xyz", osu_web_router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ py3rijndael
 python-dotenv
 python-multipart
 redis
+rich
 structlog
 uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ orjson
 pillow
 py3rijndael
 python-dotenv
-python-json-logger
 python-multipart
 redis
 structlog

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ orjson
 pillow
 py3rijndael
 python-dotenv
+python-json-logger
 python-multipart
 redis
 structlog


### PR DESCRIPTION
this is super annoying; look at how useless this `exc_info` is: https://app.datadoghq.com/logs?query=status%3Aerror%20service%3Ainterns-backend&cols=host%2Cservice&event=AgAAAYg71Zcly_8c2AAAAAAAAAAYAAAAAEFZZzcxYUdLQUFCcHg4RVNkQmlHaGdBTgAAACQAAAAAMDE4ODNiZDUtYzNjMC00OTY1LWFjNWMtZTBiM2Q5YTE5ZTE4&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1680750604418&to_ts=1680751504418&live=true